### PR TITLE
Skip `test_shutdown_stress` on Mac

### DIFF
--- a/recipe/Makefile.am.mac.patch
+++ b/recipe/Makefile.am.mac.patch
@@ -1,5 +1,5 @@
 diff --git Makefile.am Makefile.am
-index 1e7ae54..eb4d8e3 100644
+index 1e7ae54..96353b9 100644
 --- Makefile.am
 +++ Makefile.am
 @@ -277,7 +277,6 @@ curve_keygen_SOURCES = tools/curve_keygen.cpp
@@ -10,7 +10,15 @@ index 1e7ae54..eb4d8e3 100644
  	test_pair_inproc \
  	test_pair_tcp \
  	test_reqrep_inproc \
-@@ -334,9 +333,6 @@ test_apps = \
+@@ -293,7 +292,6 @@ test_apps = \
+ 	test_last_endpoint \
+ 	test_term_endpoint \
+ 	test_srcfd \
+-	test_monitor \
+ 	test_router_mandatory \
+ 	test_router_mandatory_hwm \
+ 	test_router_handover \
+@@ -334,9 +332,6 @@ test_apps = \
  	test_capabilities \
  	test_xpub_nodrop
  
@@ -20,3 +28,47 @@ index 1e7ae54..eb4d8e3 100644
  test_pair_inproc_SOURCES = \
  	tests/test_pair_inproc.cpp \
  	tests/testutil.hpp
+@@ -390,9 +385,6 @@ test_term_endpoint_LDADD = libzmq.la
+ test_srcfd_SOURCES = tests/test_srcfd.cpp
+ test_srcfd_LDADD = libzmq.la
+ 
+-test_monitor_SOURCES = tests/test_monitor.cpp
+-test_monitor_LDADD = libzmq.la
+-
+ test_router_mandatory_SOURCES = tests/test_router_mandatory.cpp
+ test_router_mandatory_LDADD = libzmq.la
+ 
+@@ -512,15 +504,11 @@ test_xpub_nodrop_LDADD = libzmq.la
+ 
+ if !ON_MINGW
+ test_apps += \
+-	test_shutdown_stress \
+ 	test_pair_ipc \
+ 	test_reqrep_ipc \
+ 	test_timeo \
+ 	test_filter_ipc
+ 
+-test_shutdown_stress_SOURCES = tests/test_shutdown_stress.cpp
+-test_shutdown_stress_LDADD = libzmq.la
+-
+ test_pair_ipc_SOURCES = \
+ 	tests/test_pair_ipc.cpp \
+ 	tests/testutil.hpp
+@@ -553,7 +541,6 @@ test_apps += \
+ 	test_reqrep_device_tipc \
+ 	test_reqrep_tipc \
+ 	test_router_mandatory_tipc \
+-	test_shutdown_stress_tipc \
+ 	test_sub_forward_tipc \
+ 	test_term_endpoint_tipc
+ 
+@@ -572,9 +559,6 @@ test_reqrep_tipc_LDADD = libzmq.la
+ test_router_mandatory_tipc_SOURCES = tests/test_router_mandatory_tipc.cpp
+ test_router_mandatory_tipc_LDADD = libzmq.la
+ 
+-test_shutdown_stress_tipc_SOURCES = tests/test_shutdown_stress_tipc.cpp
+-test_shutdown_stress_tipc_LDADD = libzmq.la
+-
+ test_sub_forward_tipc_SOURCES = tests/test_sub_forward_tipc.cpp
+ test_sub_forward_tipc_LDADD = libzmq.la
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,8 +9,10 @@ source:
   url: http://download.zeromq.org/zeromq-{{ version }}.tar.gz
   sha1: b632a4b6f8a14390dc17824e37ff7b10831ce2b4
   patches:
-    # Patch to avoid a failing test on Mac. See issue for details.
+    # Patch to avoid failing tests on Mac. See issues for details.
     # https://github.com/zeromq/libzmq/issues/1509
+    # https://github.com/zeromq/libzmq/issues/1878
+    # https://github.com/zeromq/libzmq/issues/1464
     - Makefile.am.mac.patch    # [osx]
     # Patch to avoid a failing test on Linux. See issue for details.
     # https://github.com/zeromq/libzmq/issues/1462
@@ -18,7 +20,7 @@ source:
 
 build:
   skip: true      # [win]
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
Appears [this test]( https://travis-ci.org/conda-forge/zeromq-feedstock/builds/120492345#L843 ) is now failing on Mac too. So, we add a patch to skip it here.