### PR TITLE
use normal builds on unix

### DIFF
--- a/recipe/0004-windows-cmake.patch
+++ b/recipe/0004-windows-cmake.patch
@@ -1,0 +1,30 @@
+diff --git a/ZeroMQConfig.cmake.in b/ZeroMQConfig.cmake.in
+index 00000000..9b1b5c79 100644
+--- ZeroMQConfig.cmake.in
++++ ZeroMQConfig.cmake.in
+@@ -0,0 +1,25 @@
++# ZeroMQ cmake module
++#
++# The following import targets are created
++#
++# ::
++#
++#   libzmq-static
++#   libzmq
++#
++# This module sets the following variables in your project::
++#
++#   ZeroMQ_FOUND - true if ZeroMQ found on the system
++#   ZeroMQ_INCLUDE_DIR - the directory containing ZeroMQ headers
++#   ZeroMQ_LIBRARY -
++#   ZeroMQ_STATIC_LIBRARY
++
++@PACKAGE_INIT@
++
++if(NOT TARGET libzmq AND NOT TARGET libzmq-static)
++  include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
++
++  get_target_property(@PROJECT_NAME@_INCLUDE_DIR libzmq INTERFACE_INCLUDE_DIRECTORIES)
++  get_target_property(@PROJECT_NAME@_LIBRARY libzmq LOCATION)
++  get_target_property(@PROJECT_NAME@_STATIC_LIBRARY libzmq-static LOCATION)
++endif()

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -22,8 +22,18 @@ set(_CONDA_PREFIX "$PREFIX")
 set(\${PN}_INCLUDE_DIR "\${_CONDA_PREFIX}/include")
 set(\${PN}_LIBRARY "\${_CONDA_PREFIX}/lib/libzmq${SHLIB_EXT}")
 set(\${PN}_STATIC_LIBRARY "\${_CONDA_PREFIX}/lib/libzmq.a")
+unset(_CONDA_PREFIX)
+
+set(\${PN}_FOUND TRUE)
 
 # add libzmq-4.2.3 cmake targets
+
+# only define targets once
+# this file can be loaded multiple times
+if (TARGET libzmq)
+  return()
+endif()
+
 add_library(libzmq SHARED IMPORTED)
 set_property(TARGET libzmq PROPERTY INTERFACE_INCLUDE_DIRECTORIES "\${\${PN}_INCLUDE_DIR}")
 set_property(TARGET libzmq PROPERTY IMPORTED_LOCATION "\${\${PN}_LIBRARY}")
@@ -32,7 +42,6 @@ add_library(libzmq-static STATIC IMPORTED "\${\${PN}_INCLUDE_DIR}")
 set_property(TARGET libzmq-static PROPERTY INTERFACE_INCLUDE_DIRECTORIES "\${\${PN}_INCLUDE_DIR}")
 set_property(TARGET libzmq-static PROPERTY IMPORTED_LOCATION "\${\${PN}_STATIC_LIBRARY}")
 
-set(\${PN}_FOUND TRUE)
 EOF
 
 cat << EOF > "$CMAKE_DIR/ZeroMQConfigVersion.cmake"

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,100 +1,35 @@
 #!/bin/bash
 
-EXTRA_CMAKE_ARGS=""
-if [[ `uname` == 'Darwin' ]];
-then
-    EXTRA_CMAKE_ARGS="-DZMQ_BUILD_FRAMEWORK=OFF"
-else
-    export LIBRARY_SEARCH_VAR=LD_LIBRARY_PATH
-fi
-export EXTRA_CMAKE_ARGS
-
-mkdir build
-cd build
-cmake -D WITH_PERF_TOOL=OFF -D ZMQ_BUILD_TESTS=ON -D ENABLE_CPACK=OFF -D CMAKE_BUILD_TYPE=Release -D CMAKE_INSTALL_PREFIX=$PREFIX -D CMAKE_INSTALL_LIBDIR=lib ${EXTRA_CMAKE_ARGS} ..
+./configure --prefix="$PREFIX" --with-libsodium
+make -j${NUM_CPUS}
+make check
 make install
 
-# Add missing symlink for libzmq.so.5 required for pyzmq
-# https://github.com/conda-forge/zeromq-feedstock/issues/16
-ln -f -s libzmq${SHLIB_EXT} $PREFIX/lib/libzmq${SHLIB_EXT}.5
+# Generate CMake files, so downstream packages can use `find_package(ZeroMQ)`,
+# which is normally only available when libzmq is itself installed with CMake
 
-./bin/test_ancillaries
-./bin/test_atomics
-./bin/test_base85
-./bin/test_bind_after_connect_tcp
-./bin/test_bind_src_address
-./bin/test_capabilities
-./bin/test_conflate
-./bin/test_connect_resolve
-./bin/test_connect_rid
-./bin/test_ctx_destroy
-./bin/test_ctx_options
-./bin/test_diffserv
-./bin/test_disconnect_inproc
-./bin/test_filter_ipc
-./bin/test_fork
-./bin/test_getsockopt_memset
-./bin/test_heartbeats
-./bin/test_hwm
-./bin/test_hwm_pubsub
-./bin/test_immediate
-./bin/test_inproc_connect
-./bin/test_invalid_rep
-./bin/test_iov
-./bin/test_ipc_wildcard
-./bin/test_issue_566
-./bin/test_last_endpoint
-./bin/test_many_sockets
-./bin/test_metadata
-./bin/test_monitor
-./bin/test_msg_ffn
-./bin/test_msg_flags
-./bin/test_pair_inproc
-./bin/test_pair_ipc
-./bin/test_pair_tcp
-./bin/test_probe_router
-./bin/test_proxy
-./bin/test_proxy_single_socket
-./bin/test_proxy_terminate
-./bin/test_pub_invert_matching
-./bin/test_req_correlate
-./bin/test_req_relaxed
-./bin/test_reqrep_device
-./bin/test_reqrep_inproc
-./bin/test_reqrep_ipc
-./bin/test_reqrep_tcp
-./bin/test_router_handover
-./bin/test_router_mandatory
-./bin/test_router_mandatory_hwm
-./bin/test_security_null
-./bin/test_security_plain
-./bin/test_setsockopt
-./bin/test_sockopt_hwm
-./bin/test_sodium
-./bin/test_spec_dealer
-./bin/test_spec_pushpull
-./bin/test_spec_rep
-./bin/test_spec_req
-./bin/test_spec_router
-./bin/test_srcfd
-./bin/test_stream
-./bin/test_stream_disconnect
-./bin/test_stream_empty
-./bin/test_stream_exceeds_buffer
-./bin/test_stream_timeout
-./bin/test_sub_forward
-./bin/test_term_endpoint
-./bin/test_timeo
-./bin/test_unbind_inproc
-./bin/test_unbind_wildcard
-./bin/test_use_fd_ipc
-./bin/test_use_fd_tcp
-./bin/test_xpub_manual
-./bin/test_xpub_nodrop
-./bin/test_xpub_welcome_msg
-./bin/test_zmq_poll_fd
+CMAKE_DIR="$PREFIX/share/cmake/ZeroMQ"
+mkdir -p "$CMAKE_DIR"
 
-#./bin/test_security_curve
-#./bin/test_shutdown_stress
-#./bin/test_system
-#./bin/test_thread_safe
+cat << EOF > "$CMAKE_DIR/ZeroMQConfig.cmake"
+set(PN ZeroMQ)
+set(\${PN}_INCLUDE_DIR "$PREFIX/include")
+set(\${PN}_LIBRARY "$PREFIX/lib/libzmq${SO}")
+set(\${PN}_STATIC_LIBRARY "$PREFIX/lib/libzmq.a")
+set(\${PN}_FOUND TRUE)
+EOF
+
+cat << EOF > "$CMAKE_DIR/ZeroMQConfigVersion.cmake"
+set(PACKAGE_VERSION "$PKG_VERSION")
+
+# Check whether the requested PACKAGE_FIND_VERSION is compatible
+if("\${PACKAGE_VERSION}" VERSION_LESS "\${PACKAGE_FIND_VERSION}")
+  set(PACKAGE_VERSION_COMPATIBLE FALSE)
+else()
+  set(PACKAGE_VERSION_COMPATIBLE TRUE)
+  if ("\${PACKAGE_VERSION}" VERSION_EQUAL "\${PACKAGE_FIND_VERSION}")
+    set(PACKAGE_VERSION_EXACT TRUE)
+  endif()
+endif()
+EOF
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+if [[ `uname` == Darwin ]]; then
+  export LDFLAGS="-Wl,-rpath,$PREFIX/lib $LDFLAGS"
+fi
+
 ./configure --prefix="$PREFIX" --with-libsodium
 make -j${NUM_CPUS}
 make check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ test:
     - test -f ${PREFIX}/lib/libzmq.so        # [linux]
     - test -f ${PREFIX}/lib/libzmq.so.5      # [linux]
     - test -f ${PREFIX}/lib/libzmq.dylib     # [osx]
-    - test -f ${PREFIX}/lib/libzmq.dylib.5   # [osx]
+    - test -f ${PREFIX}/lib/libzmq.5.dylib   # [osx]
     - test -f ${PREFIX}/share/cmake/ZeroMQ/ZeroMQConfig.cmake         # [unix]
     - test -f ${PREFIX}/share/cmake/ZeroMQ/ZeroMQConfigVersion.cmake  # [unix]
     - if exist %LIBRARY_LIB%\libzmq-mt-s-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,6 +49,7 @@ test:
     - test -f ${PREFIX}/lib/libzmq.5.dylib   # [osx]
     - test -f ${PREFIX}/share/cmake/ZeroMQ/ZeroMQConfig.cmake         # [unix]
     - test -f ${PREFIX}/share/cmake/ZeroMQ/ZeroMQConfigVersion.cmake  # [unix]
+    - ${PREFIX}/bin/curve_keygen  # [unix]
     - if exist %LIBRARY_LIB%\libzmq-mt-s-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)  # [win]
     - if exist %LIBRARY_BIN%\libzmq-mt-{{ version | replace('.', '_') }}.dll (exit 0) else (exit 1)    # [win]
     - if exist %LIBRARY_LIB%\libzmq-mt-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)    # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
     - 0003-windows-install.patch
 
 build:
-  number: 1
+  number: 2
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]
@@ -27,7 +27,7 @@ build:
 requirements:
   build:
     - toolchain
-    - cmake
+    - cmake  # [win]
     - libsodium  # [not (win and py27)]
     - python  # [win]
     - vc 9    # [win and py27]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,6 +14,7 @@ source:
     - 0001-remove-ascii-doc.patch
     - 0002-lrt-fix.patch
     - 0003-windows-install.patch
+    - 0004-windows-cmake.patch
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "zeromq" %}
 {% set version = "4.2.3" %}
-#{% set sha256 = "8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0" %}
-{% set sha256 = "b428c6cdf1df4b5cdcb3a6727c6ece85c7fb05d7907c532566a115b4dda113a8" %}
+{% set sha256 = "8f1e2b2aade4dbfde98d82366d61baef2f62e812530160d2e6d0a5bb24e40bc0" %}
 
 package:
   name: {{ name|lower }}
@@ -9,8 +8,7 @@ package:
 
 source:
   fn: {{ name }}-{{ version }}.tar.gz
-  #url: https://github.com/zeromq/libzmq/releases/download/v{{ version }}/zeromq-{{ version }}.tar.gz
-  url: https://github.com/zeromq/libzmq/archive/v{{ version }}.tar.gz
+  url: https://github.com/zeromq/libzmq/releases/download/v{{ version }}/zeromq-{{ version }}.tar.gz
   sha256: {{ sha256 }}
   patches:
     - 0001-remove-ascii-doc.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,7 @@ requirements:
   build:
     - toolchain
     - cmake  # [win]
+    - pkg-config  # [unix]
     - libsodium  # [not (win and py27)]
     - python  # [win]
     - vc 9    # [win and py27]


### PR DESCRIPTION
uses regular build system, rather than the relatively unused cmake builds, which require many patches and don't work reliably.

generate cmake files as a compromise for downstream projects that seem to rely on them.

fixes #20