### PR TITLE
librt hardcoded path removed

### DIFF
--- a/recipe/0002-lrt-fix.patch
+++ b/recipe/0002-lrt-fix.patch
@@ -1,0 +1,22 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2535b1..ebeb2fd 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -857,7 +857,7 @@ if (BUILD_SHARED)
+   endif ()
+ 
+   if (RT_LIBRARY)
+-    target_link_libraries (libzmq ${RT_LIBRARY})
++    target_link_libraries (libzmq -lrt)
+   endif ()
+ endif ()
+ 
+@@ -881,7 +881,7 @@ if (BUILD_SHARED)
+       target_link_libraries (${perf-tool} libzmq ${OPTIONAL_LIBRARIES})
+ 
+       if (RT_LIBRARY)
+-        target_link_libraries (${perf-tool} ${RT_LIBRARY})
++        target_link_libraries (${perf-tool} -lrt)
+       endif ()
+ 
+       if (ZMQ_BUILD_FRAMEWORK)

--- a/recipe/0003-windows-install.patch
+++ b/recipe/0003-windows-install.patch
@@ -1,0 +1,18 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index d2535b1..75e42e5 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -978,12 +978,7 @@ endif ()
+ 
+ include(CMakePackageConfigHelpers)
+ 
+-if (WIN32)
+-  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "CMake" CACHE STRING "install path for ZeroMQConfig.cmake")
+-else()
+-  # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".
+-  set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
+-endif()
++set(ZEROMQ_CMAKECONFIG_INSTALL_DIR "share/cmake/${PROJECT_NAME}" CACHE STRING "install path for ZeroMQConfig.cmake")
+ 
+ if (NOT CMAKE_VERSION VERSION_LESS 3.0)
+   export(EXPORT ${PROJECT_NAME}-targets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ source:
   patches:
     - 0001-remove-ascii-doc.patch
     - 0002-lrt-fix.patch
+    - 0003-windows-install.patch
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,10 @@ source:
   sha256: {{ sha256 }}
   patches:
     - 0001-remove-ascii-doc.patch
+    - 0002-lrt-fix.patch
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9     # [win and py27]
     - vc10    # [win and py34]


### PR DESCRIPTION
@SylvainCorlay @gouarin this should fix the issue of librt not found due to hardcoded path.
Let's fix windows installation folder too (this fix is specific to conda and should not be integrated upstream).