### PR TITLE
run_exports

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,9 @@ source:
     - 0005-osx-test.patch  # [osx]
 
 build:
-  number: 1005
+  number: 1006
+  run_exports:
+    - {{ pin_compatible(name, max_pin='x.x') }}
 
 requirements:
   build:


### PR DESCRIPTION
building against zeromq will have a runtime dependency of `zeromq>=4.2.5,<4.3`