### PR TITLE
fix and verify libsodium linking

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,13 +5,12 @@ if [[ `uname` == Darwin ]]; then
   export LDFLAGS="-Wl,-rpath,$PREFIX/lib $LDFLAGS"
 fi
 
-# find things in both build and host paths
-export PKG_CONFIG_PATH=$PREFIX/lib/pkgconfig:$BUILD_PREFIX/lib/pkgconfig
 
 if [[ `uname` == Darwin ]]; then
 ./autogen.sh
 fi
-./configure --prefix="$PREFIX" --with-libsodium="$PREFIX"
+
+./configure --prefix="$PREFIX" --with-libsodium
 make -j${CPU_COUNT}
 make check
 make install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0005-osx-test.patch  # [osx]
 
 build:
-  number: 2
+  number: 3
 
 requirements:
   build:
@@ -41,6 +41,9 @@ test:
     - test -f ${PREFIX}/lib/libzmq.so.5      # [linux]
     - test -f ${PREFIX}/lib/libzmq.dylib     # [osx]
     - test -f ${PREFIX}/lib/libzmq.5.dylib   # [osx]
+    # verify libsodium is linked
+    - otool -L ${PREFIX}/lib/libzmq.dylib | grep sodium  # [osx]
+    - ldd ${PREFIX}/lib/libzmq.so | grep sodium  # [linux]
     - test -f ${PREFIX}/lib/cmake/ZeroMQ/ZeroMQConfig.cmake         # [unix]
     - test -f ${PREFIX}/lib/cmake/ZeroMQ/ZeroMQConfigVersion.cmake  # [unix]
     - ${PREFIX}/bin/curve_keygen  # [unix]


### PR DESCRIPTION
we've been building without libsodium

`--with-libsodium=$PREFIX` doesn't work, and silently selects tweetnacl instead. It needs to be `--with-libsodium` with no args.