### PR TITLE
pin libsodium run as build x.x.x

### DIFF
--- a/recipe/conda_build_config.py
+++ b/recipe/conda_build_config.py
@@ -1,0 +1,4 @@
+pin_run_as_build:
+  libsodium:
+    max_pin: x.x.x
+    min_pin: x.x.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0005-osx-test.patch  # [osx]
 
 build:
-  number: 3
+  number: 4
 
 requirements:
   build:


### PR DESCRIPTION
since libsodium 1.0.15 is not ABI compatible with 1.0.14

closes #36

libsodium will do this itself soon with run_exports: https://github.com/conda-forge/libsodium-feedstock/pull/11