### PR TITLE
fix run_exports

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,10 +10,10 @@ environment:
     secure: tumuXLL8PU75WMnRDemRy02ruEq2RpNxeK3dz0MjFssnosPm2v4EFjfNB4PTotA1
 
   matrix:
-    - CONFIG: win_c_compilervs2008cxx_compilervs2008vc9
+    - CONFIG: win_c_compilervs2008cxx_compilervs2008
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
-    - CONFIG: win_c_compilervs2015cxx_compilervs2015vc14
+    - CONFIG: win_c_compilervs2015cxx_compilervs2015
       CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -10,12 +10,12 @@ jobs:
   strategy:
     maxParallel: 4
     matrix:
-      win_c_compilervs2008cxx_compilervs2008vc9:
-        CONFIG: win_c_compilervs2008cxx_compilervs2008vc9
+      win_c_compilervs2008cxx_compilervs2008:
+        CONFIG: win_c_compilervs2008cxx_compilervs2008
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: False
-      win_c_compilervs2015cxx_compilervs2015vc14:
-        CONFIG: win_c_compilervs2015cxx_compilervs2015vc14
+      win_c_compilervs2015cxx_compilervs2015:
+        CONFIG: win_c_compilervs2015cxx_compilervs2015
         CONDA_BLD_PATH: D:\\bld\\
         UPLOAD_PACKAGES: False
   steps:

--- a/.ci_support/win_c_compilervs2008cxx_compilervs2008.yaml
+++ b/.ci_support/win_c_compilervs2008cxx_compilervs2008.yaml
@@ -1,17 +1,11 @@
 c_compiler:
-- vs2015
+- vs2008
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2015
-pin_run_as_build:
-  vc:
-    max_pin: x
-vc:
-- '14'
+- vs2008
 zip_keys:
-- - vc
-  - c_compiler
+- - c_compiler
   - cxx_compiler

--- a/.ci_support/win_c_compilervs2015cxx_compilervs2015.yaml
+++ b/.ci_support/win_c_compilervs2015cxx_compilervs2015.yaml
@@ -1,17 +1,11 @@
 c_compiler:
-- vs2008
+- vs2015
 channel_sources:
 - conda-forge,defaults
 channel_targets:
 - conda-forge main
 cxx_compiler:
-- vs2008
-pin_run_as_build:
-  vc:
-    max_pin: x
-vc:
-- '9'
+- vs2015
 zip_keys:
-- - vc
-  - c_compiler
+- - c_compiler
   - cxx_compiler

--- a/README.md
+++ b/README.md
@@ -64,17 +64,17 @@ Current build status
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2008cxx_compilervs2008vc9</td>
+              <td>win_c_compilervs2008cxx_compilervs2008</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2248&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/zeromq-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2008cxx_compilervs2008vc9" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/zeromq-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2008cxx_compilervs2008" alt="variant">
                 </a>
               </td>
             </tr><tr>
-              <td>win_c_compilervs2015cxx_compilervs2015vc14</td>
+              <td>win_c_compilervs2015cxx_compilervs2015</td>
               <td>
                 <a href="https://dev.azure.com/conda-forge/feedstock-builds/_build/latest?definitionId=2248&branchName=master">
-                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/zeromq-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015vc14" alt="variant">
+                  <img src="https://dev.azure.com/conda-forge/feedstock-builds/_apis/build/status/zeromq-feedstock?branchName=master&jobName=win&configuration=win_c_compilervs2015cxx_compilervs2015" alt="variant">
                 </a>
               </td>
             </tr>

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,9 @@ source:
 build:
   number: 1
   run_exports:
-    - {{ pin_compatible(name, max_pin='x.x') }}
+    - {{ pin_compatible(name, max_pin='x.x') }}  # [not win]
+    # Windows DLLs have x.y.z in filename
+    - {{ pin_compatible(name, max_pin='x.x.x') }}  # [win]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0005-osx-test.patch  # [osx]
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_compatible(name, max_pin='x.x') }}
 
@@ -31,9 +31,7 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - libsodium  # [not (win and vc<14)]
-    # need non-empty host to trigger the right cb3 behavior
-    - vc  # [win and vc<14]
+    - libsodium
   run:
     - libsodium
 


### PR DESCRIPTION
Two changes:

- stop removing libsodium from host dependency, which omitted libsodium's run_exports from the dependencies, allowing too-loose installation
- specify strict x.x.x run_exports on Windows because zeromq exports include the full version in `zeromq-mt-x_x_x.dll`, which is preserved as a reference in packages like pyzmq.

```
> dumpbin /dependents env/Lib/site-packages/zmq/backend/cython/context.pyd

Dump of file envs\pyzm2\Lib\site-packages\zmq\backend\cython\context.pyd

File Type: DLL

  Image has the following dependencies:

    libzmq-mt-4_3_1.dll    <-- this is the reason for needing the pin
    python27.dll
    MSVCR90.dll
    KERNEL32.dll

```

closes #49
