### PR TITLE
Backport static builds to 4.3.2

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -8,11 +8,10 @@ fi
 autoreconf -vfi
 ./autogen.sh
 
-./configure --prefix="$PREFIX" --disable-Werror --with-libsodium --disable-static
+./configure --prefix="$PREFIX" --disable-Werror --with-libsodium
 make -j${CPU_COUNT}
 
 make check
-make install
 
 # Generate CMake files, so downstream packages can use `find_package(ZeroMQ)`,
 # which is normally only available when libzmq is itself installed with CMake
@@ -30,7 +29,7 @@ unset(_CONDA_PREFIX)
 
 set(\${PN}_FOUND TRUE)
 
-# add libzmq-4.2.3 cmake targets
+# add libzmq-4.3.3 cmake targets
 
 # only define targets once
 # this file can be loaded multiple times

--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,0 +1,8 @@
+make install
+if [[ "$PKG_NAME" == *static ]]
+then
+	# relying on conda to dedup package
+	echo "Doing nothing"
+else
+	rm -rf ${PREFIX}/lib/*a
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
     - 0005-osx-test.patch  # [osx]
 
 build:
-  number: 3
+  number: 4
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}  # [not win]
     # Windows DLLs have x.y.z in filename
@@ -37,26 +37,50 @@ requirements:
   run:
     - libsodium
 
-test:
-  commands:
-    - test ! -f ${PREFIX}/lib/libzmq.a         # [unix]
-    - test -f ${PREFIX}/lib/libzmq.so        # [linux]
-    - test -f ${PREFIX}/lib/libzmq.so.5      # [linux]
-    - test -f ${PREFIX}/lib/libzmq.dylib     # [osx]
-    - test -f ${PREFIX}/lib/libzmq.5.dylib   # [osx]
-    # verify libsodium is linked
-    - otool -L ${PREFIX}/lib/libzmq.dylib | grep sodium  # [osx]
-    - ldd ${PREFIX}/lib/libzmq.so | grep sodium  # [linux]
-    - test -f ${PREFIX}/lib/cmake/ZeroMQ/ZeroMQConfig.cmake         # [unix]
-    - test -f ${PREFIX}/lib/cmake/ZeroMQ/ZeroMQConfigVersion.cmake  # [unix]
-    - ${PREFIX}/bin/curve_keygen  # [unix]
-    - if exist %LIBRARY_LIB%\libzmq-mt-s-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)  # [win]
-    - if exist %LIBRARY_BIN%\libzmq-mt-{{ version | replace('.', '_') }}.dll (exit 0) else (exit 1)    # [win]
-    - if exist %LIBRARY_LIB%\libzmq-mt-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)    # [win]
-    - if exist %LIBRARY_BIN%\libzmq.dll (exit 0) else (exit 1)                                         # [win]
-    - if exist %LIBRARY_LIB%\libzmq.lib (exit 0) else (exit 1)                                         # [win]
-    - if exist %LIBRARY_PREFIX%\cmake\ZeroMQ\ZeroMQConfig.cmake (exit 0) else (exit 1)           # [win]
-    - if exist %LIBRARY_PREFIX%\cmake\ZeroMQ\ZeroMQConfigVersion.cmake (exit 0) else (exit 1)    # [win]
+outputs:
+  - name: zeromq
+    script: install.sh  # [unix]
+    test:
+      commands:
+        - test ! -f ${PREFIX}/lib/libzmq.a       # [unix]
+        - test -f ${PREFIX}/lib/libzmq.so        # [linux]
+        - test -f ${PREFIX}/lib/libzmq.so.5      # [linux]
+        - test -f ${PREFIX}/lib/libzmq.dylib     # [osx]
+        - test -f ${PREFIX}/lib/libzmq.5.dylib   # [osx]
+        # verify libsodium is linked
+        - otool -L ${PREFIX}/lib/libzmq.dylib | grep sodium  # [osx]
+        - ldd ${PREFIX}/lib/libzmq.so | grep sodium  # [linux]
+        - test -f ${PREFIX}/lib/cmake/ZeroMQ/ZeroMQConfig.cmake         # [unix]
+        - test -f ${PREFIX}/lib/cmake/ZeroMQ/ZeroMQConfigVersion.cmake  # [unix]
+        - ${PREFIX}/bin/curve_keygen  # [unix]
+        - if exist %LIBRARY_LIB%\libzmq-mt-s-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)  # [win]
+        - if exist %LIBRARY_BIN%\libzmq-mt-{{ version | replace('.', '_') }}.dll (exit 0) else (exit 1)    # [win]
+        - if exist %LIBRARY_LIB%\libzmq-mt-{{ version | replace('.', '_') }}.lib (exit 0) else (exit 1)    # [win]
+        - if exist %LIBRARY_BIN%\libzmq.dll (exit 0) else (exit 1)                                         # [win]
+        - if exist %LIBRARY_LIB%\libzmq.lib (exit 0) else (exit 1)                                         # [win]
+        - if exist %LIBRARY_PREFIX%\cmake\ZeroMQ\ZeroMQConfig.cmake (exit 0) else (exit 1)           # [win]
+        - if exist %LIBRARY_PREFIX%\cmake\ZeroMQ\ZeroMQConfigVersion.cmake (exit 0) else (exit 1)    # [win]
+  - name: zeromq-static
+    script: install.sh  # [unix]
+    requirements:
+      build:
+        - automake                     # [unix]
+        - autoconf                     # [unix]
+        - make                         # [unix]
+        - cmake                        # [win]
+        - libtool                      # [unix]
+        - pkg-config                   # [unix]
+        - {{ compiler('c') }}
+        - {{ compiler('cxx') }}
+      host:
+        - libsodium
+        - {{ pin_subpackage("zeromq", exact=True) }}
+      run:
+        - libsodium
+        - {{ pin_subpackage("zeromq", exact=True) }}
+    test:
+      commands:
+        - test -f ${PREFIX}/lib/libzmq.a           # [unix]
 
 about:
   home: http://zeromq.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -84,7 +84,7 @@ outputs:
 
 about:
   home: http://zeromq.org
-  license: LGPL 3
+  license: LGPL-3.0-or-later
   license_file: COPYING.LESSER
   summary: A high-performance asynchronous messaging library.
 


### PR DESCRIPTION
Backport #58 for 4.3.2 which is the current version in conda-forge-pinnings.