### PR TITLE
backport patch to fix SIGABRT when closing

### DIFF
--- a/recipe/install.sh
+++ b/recipe/install.sh
@@ -1,3 +1,5 @@
+# add this ./configure after 4.3.5
+# ./configure --disable-libsodium_randombytes_close
 make install
 if [[ "$PKG_NAME" == *static ]]
 then

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,12 @@ source:
   patches:
     - 001-windows-install.patch
     - 002-osx-test.patch  # [osx]
+    # note: add `./configure --disable-libsodium_randombytes_close` to install.sh
+    # after removing this patch when bumping to 4.3.5
+    - pr-4242.patch  # https://github.com/zeromq/libzmq/pull/4242
 
 build:
-  number: 0
+  number: 1
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x') }}  # [not win]
     # Windows DLLs have x.y.z in filename

--- a/recipe/pr-4242.patch
+++ b/recipe/pr-4242.patch
@@ -1,0 +1,27 @@
+From 63088e9fcc5c9bf3b45a18d12fb66d0345fc3e53 Mon Sep 17 00:00:00 2001
+From: Min RK <benjaminrk@gmail.com>
+Date: Fri, 13 Aug 2021 11:40:56 +0200
+Subject: [PATCH 1/2] Do not close randombytes when using libsodium
+
+randombytes_close is not threadsafe and calling it while still in use by a Context can cause a crash.
+
+For implementations using /dev/[u]random, this can leave up to one leftover FD per process.
+
+The libsodium docs suggest that this function rarely needs to be called explicitly.
+---
+ src/random.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/random.cpp b/src/random.cpp
+index 17c3537df3..12dead87ba 100644
+--- a/src/random.cpp
++++ b/src/random.cpp
+@@ -151,8 +151,6 @@ static void manage_random (bool init_)
+     if (init_) {
+         int rc = sodium_init ();
+         zmq_assert (rc != -1);
+-    } else {
+-        randombytes_close ();
+     }
+ #else
+     LIBZMQ_UNUSED (init_);


### PR DESCRIPTION
already merged upstream

upstream made the behavior opt-in for backward compatibility reasons, but it's always the right thing to do.

This applies the option unconditionally for a smaller patch.

Consequences of prior behavior: chance of SIGABRT if any context is closed or key issued while CURVE is in use.
Consequences of new behavior: up to one open FD on /dev/urandom, user may need/want to to close

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
